### PR TITLE
Enable LM75 (TMP100) driver

### DIFF
--- a/meta-lemsdr/recipes-kernel/linux/linux-adi/add_lemsdr_kernel_config.cfg
+++ b/meta-lemsdr/recipes-kernel/linux/linux-adi/add_lemsdr_kernel_config.cfg
@@ -19,6 +19,8 @@ CONFIG_CRYPTO_LZO=y
 CONFIG_SENSORS_INA2XX=y
 # Driver for TI TMP102 temperature sensor
 CONFIG_SENSORS_TMP102=y
+# Driver for TI TMP100 temperature sensor
+CONFIG_SENSORS_LM75=y
 # Clock-related options
 # Driver for RTC3231
 CONFIG_RTC_DRV_DS1307=y


### PR DESCRIPTION
Add the driver to the lemdig2 config