### PR TITLE
Add CAMLINK I2C devices to device tree and config for lm sensors

### DIFF
--- a/meta-lemsdr/recipes-bsp/device-tree/files/te0803-zynqmp/system-user.dtsi
+++ b/meta-lemsdr/recipes-bsp/device-tree/files/te0803-zynqmp/system-user.dtsi
@@ -96,21 +96,34 @@
 };
 
 &i2c0 {
-    /* LEMSDR I2C devices */
-    rf_current_33v: ina219@44 {
+    /* CAMLINK I2C devices */
+    camlink_3v3: ina219@40 {
         compatible = "ti,ina219";
-        reg = <0x44>;
-        shunt-resistor = <160000>;
+        reg = <0x40>;
+        shunt-resistor = <10000>;
     };
-    rf_temp: tmp102@48 {
-        compatible = "ti,tmp102";
+    camlink_heater: ina219@41 {
+        compatible = "ti,ina219";
+        reg = <0x41>;
+        shunt-resistor = <10000>;
+    };
+    camlink_12v: ina219@46 {
+        compatible = "ti,ina219";
+        reg = <0x46>;
+        shunt-resistor = <10000>;
+    };
+    camlink_temp1: tmp100@48 {
+        compatible = "ti,tmp100";
         reg = <0x48>;
     };
-    rf_eeprom: eeprom@50 {
-        compatible = "at,24c02";
-        reg = <0x50>;
-        pagesize = <0x10>;
-    };  
+    camlink_temp2: tmp100@4a {
+        compatible = "ti,tmp100";
+        reg = <0x4a>;
+    };
+    camlink_temp3: tmp100@4c {
+        compatible = "ti,tmp100";
+        reg = <0x4c>;
+    };
 };
 
 &i2c1 {

--- a/meta-lemsdr/recipes-bsp/lm_sensors/lmsensors-config/sensors.conf
+++ b/meta-lemsdr/recipes-bsp/lm_sensors/lmsensors-config/sensors.conf
@@ -42,11 +42,30 @@ chip "tmp102-i2c-1-4b"
 chip "tmp102-i2c-1-49"
     label temp1 "DIG Buck Temperature"
 
-chip "ina219-i2c-0-44"
-    label in0 "RF 3.3V Shunt"
-    label in1 "RF 3.3V Bus"
-    label curr1 "RF 3.3V Current"
-    label power1 "RF 3.3V Power"
+# CAMLINK devices
+chip "ina219-i2c-0-40"
+    label in0 "Camlink 3V3 Shunt"
+    label in1 "Camlink 3V3 Bus"
+    label curr1 "Camlink 3V3 Current"
+    label power1 "Camlink 3V3 Power"
 
-chip "tmp102-i2c-0-48"
-    label temp1 "RF Temperature"
+chip "ina219-i2c-0-41"
+    label in0 "Camlink Heater Shunt"
+    label in1 "Camlink Heater Bus"
+    label curr1 "Camlink Heater Current"
+    label power1 "Camlink Heater Power"
+
+chip "ina219-i2c-0-46"
+    label in0 "Camlink 12V Shunt"
+    label in1 "Camlink 12V Bus"
+    label curr1 "Camlink 12V Current"
+    label power1 "Camlink 12V Power"
+
+chip "tmp100-i2c-0-48"
+    label temp1 "Camlink Temperature 1"
+
+chip "tmp100-i2c-0-4A"
+    label temp1 "Camlink Temperature 2"
+
+chip "tmp100-i2c-0-4C"
+    label temp1 "Camlink Temperature 3"


### PR DESCRIPTION
- Add the I2C devices for CAMLINK
- Add the lm sensors config
